### PR TITLE
chore(defaults): Update webpack-defaults and move it to devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest
-      node_js: 4.3
+      node_js: 4.8
       env: WEBPACK_VERSION=latest JOB_PART=test
       script: npm run travis:$JOB_PART
     - <<: *test-latest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,6 +19,7 @@ matrix:
   fast_finish: true
 install:
   - 'ps: Install-Product node $env:nodejs_version x64'
+  - npm i -g npm@latest
   - npm install
 before_test:
   - 'cmd: npm install webpack@%webpack_version%'

--- a/package.json
+++ b/package.json
@@ -28,8 +28,7 @@
   "dependencies": {
     "asciify-pixel-matrix": "^1.0.8",
     "bundle-buddy": "^0.1.2",
-    "chalk": "^2.0.1",
-    "webpack-defaults": "^1.5.0"
+    "chalk": "^2.0.1"
   },
   "main": "dist/cjs.js",
   "files": [
@@ -66,6 +65,7 @@
     "nsp": "^2.6.3",
     "pre-commit": "^1.2.2",
     "standard-version": "^4.2.0",
-    "webpack": "^3.2.0"
+    "webpack": "^3.2.0",
+    "webpack-defaults": "^1.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,9 +3166,16 @@ js-tokens@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.8.2, js-yaml@^3.8.4:
+js-yaml@^3.4.3, js-yaml@^3.7.0, js-yaml@^3.8.4:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.9.0.tgz#4ffbbf25c2ac963b8299dc74da7e3740de1c18ce"
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.8.2:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -5179,9 +5186,9 @@ webidl-conversions@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.1.tgz#8015a17ab83e7e1b311638486ace81da6ce206a0"
 
-webpack-defaults@^1.5.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/webpack-defaults/-/webpack-defaults-1.5.0.tgz#5ef83bc37ec241599fdde657d9db6793c677955f"
+webpack-defaults@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/webpack-defaults/-/webpack-defaults-1.6.0.tgz#0eb33b36860e3bafbf035f78ca06139f658b3dda"
   dependencies:
     chalk "^1.1.3"
     mrm-core "^1.1.0"


### PR DESCRIPTION
This PR move `webpack-defaults` to `devDependencies` so consumer of this plugin don't have the npm script added to their `package.json` by the post install script.

While I was there, I took the opportunity to bump it to its last version. Tell me if it's something you don't want and I'll ditch this part.

Thanks for the plugin in any case!