### PR TITLE
fix: upgrade to bundle-buddy 0.2.1 to return exit code 0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "asciify-pixel-matrix": "^1.0.8",
-    "bundle-buddy": "^0.1.2",
+    "bundle-buddy": "^0.2.1",
     "chalk": "^2.0.1"
   },
   "main": "dist/cjs.js",


### PR DESCRIPTION
Problem:

Currently if you use this plugin within an npm script it will fail even though it actually succeeded due to the incorrect exit code that bundle-buddy used to send (pre 0.2.1). 

Expected behavior:

This upgrades the bundle-buddy version so that this plugin also returns a correct error code.