### PR TITLE
fix: upgrade bundle-budy package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "asciify-pixel-matrix": "^1.0.8",
-    "bundle-buddy": "^0.2.1",
+    "bundle-buddy": "^0.2.2",
     "chalk": "^2.0.1"
   },
   "main": "dist/cjs.js",


### PR DESCRIPTION
hi
currently released plugin package (3.0.0) still relies on outdated dependency (`"bundle-buddy": "^0.1.2"`) which has very misleading exit code 1 for "no duplicates" case. would be great to bump plugin version & make a release, thanks